### PR TITLE
Hotfix: Python version check & Logger initialisation

### DIFF
--- a/cogs/connectors/api_server.py
+++ b/cogs/connectors/api_server.py
@@ -920,7 +920,6 @@ async def fetch_server_ping_response():
             response_text = await response.text()
             return response.status, response_text
 
-
 async def start_api_server(config, game_servers_dict, game_manager_tasks, health_tasks, event_bus, find_replay_callback, host="0.0.0.0", port=5000):
     global global_config, game_servers, manager_event_bus, manager_tasks, health_check_tasks, manager_find_replay_callback, manager_check_game_stats_callback
     global_config = config

--- a/cogs/misc/dependencies_check.py
+++ b/cogs/misc/dependencies_check.py
@@ -6,14 +6,15 @@ class PrepareDependencies:
     def __init__(self, home_path):
         self.script_home = home_path
         self.python_version = sys.version_info[:2]
-        if self.python_version == (3, 9):
-            self.pip_requirements = home_path / "py3.9" / "requirements.txt"
-        if self.python_version == (3, 10):
-            self.pip_requirements = home_path / "py3.10" / "requirements.txt"
-        elif self.python_version == (3, 11):
-            self.pip_requirements = home_path / "py3.11" / "requirements.txt"
-        else:
+        if self.python_version[0] != 3:
             raise RuntimeError(f"Unsupported Python version: {sys.version}")
+        elif self.python_version[1] < 9:
+            raise RuntimeError(f"Python version too old: {sys.version}")
+        elif self.python_version[1] > 11:
+            raise RuntimeError(f"Python version too new: {sys.version}")
+        else:
+            minor_version = self.python_version[1]
+            self.pip_requirements = home_path / f"py3.{minor_version}" / "requirements.txt"
 
     def get_required_packages(self):
         try:

--- a/cogs/misc/logger.py
+++ b/cogs/misc/logger.py
@@ -110,6 +110,8 @@ def set_logger():
         pt_handler = PromptToolkitLogHandler()
         pt_handler.setFormatter(CustomFormatter())
         pt_handler.setLevel(logging.INFO)
+        
+        logger = logging.getLogger('Server')
 
         logger.addHandler(file_handler)
         logger.addHandler(pt_handler)


### PR DESCRIPTION
1. Python version check failed in 1 case. Added more verbose logging output for which is the detected version.
2. logger initialization appeared to be missing after one of the recent changes