### PR TITLE
Reschedule filebeat setup task nightly

### DIFF
--- a/cogs/game/healthcheck_manager.py
+++ b/cogs/game/healthcheck_manager.py
@@ -53,6 +53,12 @@ class HealthCheckManager:
                     # Task is still running
                     LOGGER.debug(f"Task '{name}' is still running, new task not scheduled.")
                     return existing_task  # Return existing task
+                else:
+                    try:
+                        self.tasks['name'].cancel()
+                    except Exception:
+                        LOGGER.error(f"Failed to cancel existing task: {name}")
+                        LOGGER.error(traceback.format_exc())
 
         # Create and register the new task
         task = asyncio.create_task(coro)
@@ -132,7 +138,7 @@ class HealthCheckManager:
                 await asyncio.sleep(1)
             try:
                 # await filebeat_setup(self.global_config)
-                self.schedule_task(filebeat_setup(self.global_config),'spawned_filebeat_setup')
+                self.schedule_task(filebeat_setup(self.global_config),'spawned_filebeat_setup', override=True)
             except Exception:
                 LOGGER.error(traceback.format_exc())
             for _ in range(self.global_config['application_data']['timers']['manager']['filebeat_verification']):

--- a/cogs/misc/logger.py
+++ b/cogs/misc/logger.py
@@ -67,11 +67,9 @@ def get_filebeat_auth_token():
 
 def set_filebeat_auth_url(url):
     global FILEBEAT_AUTH_URL
-    logger.info("Setting oauth url")
     FILEBEAT_AUTH_URL = url
 
 def get_filebeat_auth_url():
-    logger.info("Unsetting oauth url")
     return FILEBEAT_AUTH_URL
 
 def set_logger():

--- a/utilities/filebeat.py
+++ b/utilities/filebeat.py
@@ -559,46 +559,54 @@ def remove_cron_job(command):
         print_or_log('error',f"Failed to remove cron job: {e}")
 
 async def main(config=None):
-    global global_config
+    try:
+        global global_config
 
-    global_config = config
-    # Parse command-line arguments
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-silent", action="store_true", help="Run in silent mode without asking for Discord ID")
-    parser.add_argument("-test", action="store_true", help="Use an experimental filebeat configuration file")
-    args = parser.parse_args()
+        global_config = config
+        # Parse command-line arguments
+        parser = argparse.ArgumentParser()
+        parser.add_argument("-silent", action="store_true", help="Run in silent mode without asking for Discord ID")
+        parser.add_argument("-test", action="store_true", help="Use an experimental filebeat configuration file")
+        args = parser.parse_args()
 
-    print_or_log('info','Setting up Filebeat. This is used to submit game match logs for trend analysis and is required by game server hosts.')
-    if not check_filebeat_installed():
-        await install_filebeat()
-    
-    if __name__ == "__main__":
-        await step_certificate.main(stop_event)
-    else: await step_certificate.main(stop_event, LOGGER, set_filebeat_auth_token, set_filebeat_auth_url)
+        print_or_log('info', 'Setting up Filebeat. This is used to submit game match logs for trend analysis and is required by game server hosts.')
+        if not check_filebeat_installed():
+            await install_filebeat()
 
-    filebeat_changed = False
-    if await configure_filebeat(silent=args.silent, test=args.test):
-        filebeat_changed = True
-        # Delete scheduled task on Windows
-        if operating_system == "Windows":
-            task_name = "Filebeat Task"
+        if __name__ == "__main__":
+            await step_certificate.main(stop_event)
+        else:
+            await step_certificate.main(stop_event, LOGGER, set_filebeat_auth_token, set_filebeat_auth_url)
 
-            # Check if the task already exists
-            task_query = subprocess.run(["schtasks", "/query", "/tn", task_name], capture_output=True, text=True)
-            if "ERROR: The system cannot find the file specified." not in task_query.stderr:
-                # Delete the scheduled task
-                subprocess.run(["schtasks", "/delete", "/tn", task_name, "/f"])
-                print_or_log('info',"Scheduled task deleted successfully.")
+        filebeat_changed = False
+        if await configure_filebeat(silent=args.silent, test=args.test):
+            filebeat_changed = True
+            # Delete scheduled task on Windows
+            if operating_system == "Windows":
+                task_name = "Filebeat Task"
 
-        # Delete cron job on Linux
-        if operating_system == "Linux":
-            script_path = os.path.abspath(__file__)
-            command = f"python3 {script_path} -silent"
-            remove_cron_job(command)
-            print_or_log('info',"Cron job deleted successfully.")
+                # Check if the task already exists
+                task_query = subprocess.run(["schtasks", "/query", "/tn", task_name], capture_output=True, text=True)
+                if "ERROR: The system cannot find the file specified." not in task_query.stderr:
+                    # Delete the scheduled task
+                    subprocess.run(["schtasks", "/delete", "/tn", task_name, "/f"])
+                    print_or_log('info', "Scheduled task deleted successfully.")
 
-    # if filebeat_changed:
-    await restart_filebeat(filebeat_changed, silent=args.silent)
+            # Delete cron job on Linux
+            if operating_system == "Linux":
+                script_path = os.path.abspath(__file__)
+                command = f"python3 {script_path} -silent"
+                remove_cron_job(command)
+                print_or_log('info', "Cron job deleted successfully.")
+
+        # if filebeat_changed:
+        await restart_filebeat(filebeat_changed, silent=args.silent)
+
+    except asyncio.CancelledError:
+        # Perform any necessary cleanup or handling for cancellation here
+        print_or_log('info', 'Filebeat setup task was canceled. Performing cleanup...')
+        # Cleanup code goes here - can't think of any.
+        return  # suppress the CancelledError and not propagate it further
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
This is to so that a new ouath request is made every night at least, rather than reminding the user of the initial oauth request when maybe the backend server has been reloaded and forgotten about it.