### PR TITLE
Added /register endpoint for users connecting to server

### DIFF
--- a/cogs/connectors/api_server.py
+++ b/cogs/connectors/api_server.py
@@ -140,6 +140,10 @@ API Endpoints below
 """Unprotected Endpoints"""
 class PingResponse(BaseModel):
     status: str
+@app.get("/api/public/ping", response_model=PingResponse, description="Responds with the a simple pong to indicate server is alive.")
+async def ping():
+    return {"status":"OK"}
+# temp. Leaving old endpoint name in place to facilitate any migration works
 @app.get("/api/ping", response_model=PingResponse, description="Responds with the a simple pong to indicate server is alive.")
 async def ping():
     return {"status":"OK"}
@@ -180,6 +184,12 @@ async def filebeat_installed():
 
 
 """Protected Endpoints"""
+"""Client registration to add server"""
+class RegistrationResponse(BaseModel):
+    status: str
+@app.get("/api/register", response_model=RegistrationResponse, description="Used to verify a client has permission to add the server")
+async def ping(token_and_user_info: dict = Depends(check_permission_factory(required_permission="monitor"))):
+    return {"status":"OK"}
 
 """Config Types"""
 class GlobalConfigResponse(BaseModel):


### PR DESCRIPTION
Used to be /ping, but /ping is a public endpoint. /register is not, therefore /register should be used for users adding the server in the management web portal.

Renamed /ping endpoing to /public/ping. Left a duplicate of /ping to allow for any migration issues.