### PR TITLE
Cowserver kill stuck games

### DIFF
--- a/cogs/TCP/game_packet_lsnr.py
+++ b/cogs/TCP/game_packet_lsnr.py
@@ -73,7 +73,7 @@ class ClientConnection:
                 LOGGER.error(f"Client #{self.id} Timeout. The connection has timed out between the GameServer and the Manager. {timeout} seconds without receiving any data. Shutting down Game Server.")
                 if self.game_server:
                     # await self.game_server.schedule_task(self.game_server.tail_game_log_then_close(), 'orphan_game_server_disconnect')
-                    await game_server.stop_server_exe(disable=False)
+                    await game_server.stop_server_exe(disable=False, kill=True)
                     await self.close()
                     await self.game_server_manager.start_game_servers([game_server], service_recovery=True)
 

--- a/cogs/game/game_server.py
+++ b/cogs/game/game_server.py
@@ -821,7 +821,7 @@ region=naeu
                     except psutil.NoSuchProcess:
                         status = 'stopped'
                     if status in ['zombie', 'stopped'] and self.enabled:  # If the process is defunct or stopped. a "suspended" process will also show as stopped on windows.
-                        LOGGER.warn(f"GameServer #{self.id} stopped unexpectedly")
+                        LOGGER.warn(f"GameServer #{self.id} stopped unexpectedly. (Process ID: {self._proc_hook.pid})")
                         self._proc = None  # Reset the process reference
                         self._proc_hook = None  # Reset the process hook reference
                         self._pid = None

--- a/cogs/game/game_server.py
+++ b/cogs/game/game_server.py
@@ -614,7 +614,7 @@ class GameServer:
         # Close the tailing
         await self.stop_server_exe(disable=False)
 
-    async def stop_server_exe(self, disable=True, delete=False):
+    async def stop_server_exe(self, disable=True, delete=False, kill=False):
         if disable:
             self.disable_server()
         self.delete_me = delete
@@ -622,7 +622,10 @@ class GameServer:
             if disable:
                 self.disable_server()
             try:
-                self._proc.terminate()
+                if kill:
+                    self._proc.kill()
+                else:
+                    self._proc.terminate()
             except psutil.NoSuchProcess:
                 pass # process doesn't exist, probably race condition of something else terminating it.
             self.started = False

--- a/cogs/game/game_server_manager.py
+++ b/cogs/game/game_server_manager.py
@@ -174,7 +174,7 @@ class GameServerManager:
         self.tasks[name] = task
         return task
     
-    async def cmd_shutdown_server(self, game_server=None, force=False, delay=0, delete=False, disable=True):
+    async def cmd_shutdown_server(self, game_server=None, force=False, delay=0, delete=False, disable=True, kill=False):
         try:
             if game_server is None: return False
             client_connection = self.client_connections.get(game_server.port, None)
@@ -193,7 +193,7 @@ class GameServerManager:
                     return True
             else:
                 # this server hasn't connected to the manager yet
-                await game_server.stop_server_exe(disable=disable, delete=delete)
+                await game_server.stop_server_exe(disable=disable, delete=delete, kill=kill)
                 game_server.reset_game_state()
                 return True
         except Exception as e:

--- a/cogs/game/healthcheck_manager.py
+++ b/cogs/game/healthcheck_manager.py
@@ -1,7 +1,7 @@
 
 from cogs.handlers.events import stop_event, get_logger
 from cogs.misc.logger import get_logger, get_misc
-from cogs.misc.exceptions import HoNPatchError
+from cogs.handlers.events import GameStatus
 from utilities.filebeat import main as filebeat_setup
 import asyncio
 import traceback
@@ -102,8 +102,9 @@ class HealthCheckManager:
                     pass
                 
                 if not game_server.client_connection and game_server.started:
-                    LOGGER.info(f"GameServer #{game_server.id} - Idle / stuck game server.")
-                    await self.event_bus.emit('cmd_shutdown_server',game_server)
+                    if not game_server.get_dict_value('status') == GameStatus.STARTING.value:
+                        LOGGER.info(f"GameServer #{game_server.id} - Idle / stuck game server.")
+                        await self.event_bus.emit('cmd_shutdown_server',game_server)
                 
 
             for proc in proxy_procs:

--- a/cogs/game/healthcheck_manager.py
+++ b/cogs/game/healthcheck_manager.py
@@ -70,7 +70,7 @@ class HealthCheckManager:
         while not stop_event.is_set():
             for _ in range(self.global_config['application_data']['timers']['manager']['public_ip_healthcheck']):
                 if stop_event.is_set():
-                    break
+                    return
                 await asyncio.sleep(1)
             public_ip = await MISC.lookup_public_ip_async()
             if public_ip and public_ip != self.global_config['hon_data']['svr_ip']:
@@ -81,7 +81,7 @@ class HealthCheckManager:
         while not stop_event.is_set():
             for _ in range(self.global_config['application_data']['timers']['manager']['general_healthcheck']):
                 if stop_event.is_set():
-                    break
+                    return
                 await asyncio.sleep(1)
 
             proxy_procs = []
@@ -103,7 +103,7 @@ class HealthCheckManager:
 
                 status_value = game_server.get_dict_value('status')
 
-                if status_value not in GameStatus._value2member_map_:
+                if status_value not in GameStatus._value2member_map_ and not game_server.client_connection:
                     LOGGER.info(f"GameServer #{game_server.id} - Idle / stuck game server.")
                     await self.event_bus.emit('cmd_shutdown_server',game_server, kill=True)
                 
@@ -116,7 +116,7 @@ class HealthCheckManager:
         while not stop_event.is_set():
             for _ in range(self.global_config['application_data']['timers']['manager']['lag_healthcheck']):
                 if stop_event.is_set():
-                    break
+                    return
                 await asyncio.sleep(1)
             for game_server in self.game_servers.values():
                 # Perform the lag health check for each game server
@@ -127,7 +127,7 @@ class HealthCheckManager:
         while not stop_event.is_set():
             for _ in range(self.global_config['application_data']['timers']['manager']['check_for_hon_update']):
                 if stop_event.is_set():
-                    break
+                    return
                 await asyncio.sleep(1)
             try:
                 if not MISC.get_os_platform() == "win32": # TODO: not checking patch on linux yet
@@ -142,7 +142,7 @@ class HealthCheckManager:
         while not stop_event.is_set():
             for _ in range(self.global_config['application_data']['timers']['manager']['filebeat_verification']):
                 if stop_event.is_set():
-                    break
+                    return
                 await asyncio.sleep(1)
             try:
                 # await filebeat_setup(self.global_config)
@@ -154,7 +154,7 @@ class HealthCheckManager:
         while not stop_event.is_set():
             for _ in range(self.global_config['application_data']['timers']['manager']['check_for_honfigurator_update']):
                 if stop_event.is_set():
-                    break
+                    return
                 await asyncio.sleep(1)
             try:
                 await self.event_bus.emit('update')
@@ -165,7 +165,7 @@ class HealthCheckManager:
         while not stop_event.is_set():
             for _ in range(10):
                 if stop_event.is_set():
-                    break
+                    return
                 await asyncio.sleep(1)
             try:
                 for file_name in os.listdir(self.global_config['hon_data']['hon_logs_directory']):
@@ -185,7 +185,7 @@ class HealthCheckManager:
         while not stop_event.is_set():
             for _ in range(self.global_config['application_data']['timers']['manager']['general_healthcheck']):
                 if stop_event.is_set():
-                    break
+                    return
                 await asyncio.sleep(1)
 
     async def run_health_checks(self):
@@ -228,5 +228,5 @@ class HealthCheckManager:
             for _ in range(10):
                 if stop_event.is_set():
                     LOGGER.info("Stopping HealthCheck Manager")
-                    break
+                    return
                 await asyncio.sleep(1)

--- a/cogs/game/healthcheck_manager.py
+++ b/cogs/game/healthcheck_manager.py
@@ -101,7 +101,7 @@ class HealthCheckManager:
                     # Example: self.perform_health_check(game_server, HealthChecks.general_healthcheck)
                     pass
 
-                status_value = self.get_dict_value('status')
+                status_value = game_server.get_dict_value('status')
 
                 if status_value not in GameStatus._value2member_map_:
                     LOGGER.info(f"GameServer #{game_server.id} - Idle / stuck game server.")

--- a/cogs/game/healthcheck_manager.py
+++ b/cogs/game/healthcheck_manager.py
@@ -100,9 +100,15 @@ class HealthCheckManager:
                     # Perform the general health check for each game server
                     # Example: self.perform_health_check(game_server, HealthChecks.general_healthcheck)
                     pass
+                
+                if not game_server.client_connection and game_server.started:
+                    LOGGER.info(f"GameServer #{game_server.id} - Idle / stuck game server.")
+                    await self.event_bus.emit('cmd_shutdown_server',game_server)
+                
+
             for proc in proxy_procs:
-                LOGGER.info(f"WHAT-IF: Removed orphan proxy.exe ({proc.pid}) process. It is not associated with any currently connected game server instances.")
-                # proc.terminate()
+                # LOGGER.info(f"WHAT-IF: Removed orphan proxy.exe ({proc.pid}) process. It is not associated with any currently connected game server instances.")
+                proc.terminate()
 
     async def lag_healthcheck(self):
         while not stop_event.is_set():

--- a/cogs/game/healthcheck_manager.py
+++ b/cogs/game/healthcheck_manager.py
@@ -100,11 +100,12 @@ class HealthCheckManager:
                     # Perform the general health check for each game server
                     # Example: self.perform_health_check(game_server, HealthChecks.general_healthcheck)
                     pass
-                
-                if not game_server.client_connection and game_server.started:
-                    if not game_server.get_dict_value('status') == GameStatus.STARTING.value:
-                        LOGGER.info(f"GameServer #{game_server.id} - Idle / stuck game server.")
-                        await self.event_bus.emit('cmd_shutdown_server',game_server)
+
+                status_value = self.get_dict_value('status')
+
+                if status_value not in GameStatus._value2member_map_:
+                    LOGGER.info(f"GameServer #{game_server.id} - Idle / stuck game server.")
+                    await self.event_bus.emit('cmd_shutdown_server',game_server, kill=True)
                 
 
             for proc in proxy_procs:

--- a/cogs/game/healthcheck_manager.py
+++ b/cogs/game/healthcheck_manager.py
@@ -105,7 +105,7 @@ class HealthCheckManager:
 
                 if status_value not in GameStatus._value2member_map_ and not game_server.client_connection:
                     LOGGER.info(f"GameServer #{game_server.id} - Idle / stuck game server.")
-                    await self.event_bus.emit('cmd_shutdown_server',game_server, kill=True)
+                    await self.event_bus.emit('cmd_shutdown_server',game_server, disable=False, kill=True)
                 
 
             for proc in proxy_procs:

--- a/main.py
+++ b/main.py
@@ -92,8 +92,7 @@ async def main():
     # check for other HoNfigurator instances.
     check_existing_proc = MISC.get_process_by_port(global_config['hon_data']['svr_managerPort'], protocol='tcp4')
     if check_existing_proc:
-        LOGGER.error(f"A manager is already running on port {global_config['hon_data']['svr_managerPort']}")
-        return
+        LOGGER.critical(f"A manager is already running on port {global_config['hon_data']['svr_managerPort']}. This may prevent the manager from operating correctly.")
 
     # run scheduler
     jobs = HonfiguratorSchedule(global_config)

--- a/main.py
+++ b/main.py
@@ -92,7 +92,8 @@ async def main():
     # check for other HoNfigurator instances.
     check_existing_proc = MISC.get_process_by_port(global_config['hon_data']['svr_managerPort'], protocol='tcp4')
     if check_existing_proc:
-        check_existing_proc.terminate()
+        LOGGER.error(f"A manager is already running on port {global_config['hon_data']['svr_managerPort']}")
+        return
 
     # run scheduler
     jobs = HonfiguratorSchedule(global_config)


### PR DESCRIPTION
This change will ensure that games which cannot connect to manager are killed.
Changes are
 - kill instance using .kill() instead of .terminate(), as these instances are stuck.
   - this happens from a healthcheck interval, or from timing out from the manager in a live scenario
 - implement the proxy cleanup script for windows. It has been in test for months and I've reviewed server logs to ensure it works