### PR TITLE
Add LXS (beta) patch support

### DIFF
--- a/cogs/connectors/masterserver_connector.py
+++ b/cogs/connectors/masterserver_connector.py
@@ -18,6 +18,7 @@ class MasterServerHandler:
         self.version = version
         self.was = "was-crIac6LASwoafrl8FrOa"
         self.las = "las-crIac6LASwoafrl8FrOa"
+        self.lxs = "lxs-crIac6LASwoafrl8FrOa"
         self.architecture = architecture
         if MISC.get_os_platform() == "win32":
             self.arch_platform = "x86_64"

--- a/cogs/game/game_server_manager.py
+++ b/cogs/game/game_server_manager.py
@@ -52,8 +52,8 @@ class GameServerManager:
         self.HON_LAS_LAUNCHER_DOWNLOAD_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/las-crIac6LASwoafrl8FrOa/x86-biarch/launcher.zip"
         if "svr_beta_mode" in self.global_config['hon_data'] and self.global_config['hon_data']['svr_beta_mode']:
             self.global_config['hon_data']['architecture'] == "lxs-crIac6LASwoafrl8FrOa"
-            self.HON_LAS_VERSION_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/lxs-crIac6LASwoafrl8FrOa/x86_64/version.cfg"
-            self.HON_LAS_LAUNCHER_DOWNLOAD_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/lxs-crIac6LASwoafrl8FrOa/x86_64/launcher.zip"
+            self.HON_LAS_VERSION_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/lxs-crIac6LASwoafrl8FrOa/x86-biarch/version.cfg"
+            self.HON_LAS_LAUNCHER_DOWNLOAD_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/lxs-crIac6LASwoafrl8FrOa/x86-biarch/launcher.zip"
         """
         Event Subscriptions. These are used to call other parts of the code in an event-driven approach within async functions.
         """

--- a/cogs/game/game_server_manager.py
+++ b/cogs/game/game_server_manager.py
@@ -33,10 +33,6 @@ import random
 LOGGER = get_logger()
 MISC = get_misc()
 HOME_PATH = get_home()
-HON_WAS_VERSION_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/was-crIac6LASwoafrl8FrOa/x86_64/version.cfg"
-HON_WAS_LAUNCHER_DOWNLOAD_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/was-crIac6LASwoafrl8FrOa/x86_64/hon_update_x64.zip"
-HON_LAS_VERSION_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/las-crIac6LASwoafrl8FrOa/x86-biarch/version.cfg"
-HON_LAS_LAUNCHER_DOWNLOAD_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/las-crIac6LASwoafrl8FrOa/x86-biarch/launcher.zip"
 
 class GameServerManager:
     def __init__(self, global_config, setup):
@@ -47,6 +43,16 @@ class GameServerManager:
         global_config (dict): A dictionary containing the global configuration for the game server.
         """
         self.global_config = global_config
+        """
+        Global class configuration. These are URLs for retrieval of game data for patching and updates.
+        """
+        self.HON_WAS_VERSION_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/was-crIac6LASwoafrl8FrOa/x86_64/version.cfg"
+        self.HON_WAS_LAUNCHER_DOWNLOAD_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/was-crIac6LASwoafrl8FrOa/x86_64/hon_update_x64.zip"
+        self.HON_LAS_VERSION_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/las-crIac6LASwoafrl8FrOa/x86-biarch/version.cfg"
+        self.HON_LAS_LAUNCHER_DOWNLOAD_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/las-crIac6LASwoafrl8FrOa/x86-biarch/launcher.zip"
+        if "svr_beta_mode" in self.global_config and self.global_config["svr_beta_mode"]:
+            self.HON_LAS_VERSION_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/lxs-crIac6LASwoafrl8FrOa/x86_64/version.cfg"
+            self.HON_LAS_LAUNCHER_DOWNLOAD_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/lxs-crIac6LASwoafrl8FrOa/x86_64/launcher.zip"
         """
         Event Subscriptions. These are used to call other parts of the code in an event-driven approach within async functions.
         """

--- a/cogs/game/game_server_manager.py
+++ b/cogs/game/game_server_manager.py
@@ -1171,13 +1171,13 @@ class GameServerManager:
         if MISC.get_os_platform() == "win32":
             launcher_binary = 'hon_update_x64.exe'
             launcher_zip = 'hon_update_x64.zip'
-            hon_version_url = HON_WAS_VERSION_URL
-            launcher_download_url = HON_WAS_LAUNCHER_DOWNLOAD_URL
+            hon_version_url = self.HON_WAS_VERSION_URL
+            launcher_download_url = self.HON_WAS_LAUNCHER_DOWNLOAD_URL
         else:
             launcher_binary = 'launcher'
             launcher_zip = 'launcher.zip'
-            hon_version_url = HON_LAS_VERSION_URL
-            launcher_download_url = HON_LAS_LAUNCHER_DOWNLOAD_URL
+            hon_version_url = self.HON_LAS_VERSION_URL
+            launcher_download_url = self.HON_LAS_LAUNCHER_DOWNLOAD_URL
 
         launcher_crc = await self.patch_extract_crc_from_file(hon_version_url)
         if not launcher_crc:

--- a/cogs/game/game_server_manager.py
+++ b/cogs/game/game_server_manager.py
@@ -51,7 +51,7 @@ class GameServerManager:
         self.HON_LAS_VERSION_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/las-crIac6LASwoafrl8FrOa/x86-biarch/version.cfg"
         self.HON_LAS_LAUNCHER_DOWNLOAD_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/las-crIac6LASwoafrl8FrOa/x86-biarch/launcher.zip"
         if "svr_beta_mode" in self.global_config and self.global_config["svr_beta_mode"]:
-            self.global_config['hon_data']['architecture'] == "lxs"
+            self.global_config['hon_data']['architecture'] == "lxs-crIac6LASwoafrl8FrOa"
             self.HON_LAS_VERSION_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/lxs-crIac6LASwoafrl8FrOa/x86_64/version.cfg"
             self.HON_LAS_LAUNCHER_DOWNLOAD_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/lxs-crIac6LASwoafrl8FrOa/x86_64/launcher.zip"
         """

--- a/cogs/game/game_server_manager.py
+++ b/cogs/game/game_server_manager.py
@@ -50,7 +50,7 @@ class GameServerManager:
         self.HON_WAS_LAUNCHER_DOWNLOAD_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/was-crIac6LASwoafrl8FrOa/x86_64/hon_update_x64.zip"
         self.HON_LAS_VERSION_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/las-crIac6LASwoafrl8FrOa/x86-biarch/version.cfg"
         self.HON_LAS_LAUNCHER_DOWNLOAD_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/las-crIac6LASwoafrl8FrOa/x86-biarch/launcher.zip"
-        if "svr_beta_mode" in self.global_config and self.global_config["svr_beta_mode"]:
+        if "svr_beta_mode" in self.global_config['hon_data'] and self.global_config['hon_data']['svr_beta_mode']:
             self.global_config['hon_data']['architecture'] == "lxs-crIac6LASwoafrl8FrOa"
             self.HON_LAS_VERSION_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/lxs-crIac6LASwoafrl8FrOa/x86_64/version.cfg"
             self.HON_LAS_LAUNCHER_DOWNLOAD_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/lxs-crIac6LASwoafrl8FrOa/x86_64/launcher.zip"

--- a/cogs/game/game_server_manager.py
+++ b/cogs/game/game_server_manager.py
@@ -51,6 +51,7 @@ class GameServerManager:
         self.HON_LAS_VERSION_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/las-crIac6LASwoafrl8FrOa/x86-biarch/version.cfg"
         self.HON_LAS_LAUNCHER_DOWNLOAD_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/las-crIac6LASwoafrl8FrOa/x86-biarch/launcher.zip"
         if "svr_beta_mode" in self.global_config and self.global_config["svr_beta_mode"]:
+            self.global_config['hon_data']['architecture'] == "lxs"
             self.HON_LAS_VERSION_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/lxs-crIac6LASwoafrl8FrOa/x86_64/version.cfg"
             self.HON_LAS_LAUNCHER_DOWNLOAD_URL = "http://gitea.kongor.online/administrator/KONGOR/raw/branch/main/patch/lxs-crIac6LASwoafrl8FrOa/x86_64/launcher.zip"
         """

--- a/cogs/game/game_server_manager.py
+++ b/cogs/game/game_server_manager.py
@@ -423,6 +423,8 @@ class GameServerManager:
             parsed_patch_information = phpserialize.loads(patch_information[0].encode('utf-8'))
             parsed_patch_information = {key.decode() if isinstance(key, bytes) else key: (value.decode() if isinstance(value, bytes) else value) for key, value in parsed_patch_information.items()}
             LOGGER.debug(f"Upstream patch information: {parsed_patch_information}")
+            if self.global_config['hon_data']['svr_beta_mode']:
+                parsed_patch_information['latest'] = "4.11.0"
             self.latest_available_game_version = parsed_patch_information['latest']
 
             if local_svr_version != self.latest_available_game_version:

--- a/cogs/game/game_server_manager.py
+++ b/cogs/game/game_server_manager.py
@@ -423,8 +423,6 @@ class GameServerManager:
             parsed_patch_information = phpserialize.loads(patch_information[0].encode('utf-8'))
             parsed_patch_information = {key.decode() if isinstance(key, bytes) else key: (value.decode() if isinstance(value, bytes) else value) for key, value in parsed_patch_information.items()}
             LOGGER.debug(f"Upstream patch information: {parsed_patch_information}")
-            if self.global_config['hon_data']['svr_beta_mode']:
-                parsed_patch_information['latest'] = "4.11.0"
             self.latest_available_game_version = parsed_patch_information['latest']
 
             if local_svr_version != self.latest_available_game_version:

--- a/cogs/handlers/commands.py
+++ b/cogs/handlers/commands.py
@@ -386,7 +386,7 @@ class Commands:
                 print_formatted_text("Usage: command <GameServer#> <command>")
                 return
             
-            if isinstance(command[0],str) and command[0].lower() not in ['message','terminateplayer','serverreset','flushserverlogs']:
+            if isinstance(command[0],str) and command[0].lower() not in ['message','terminateplayer','serverreset','flushserverlogs', 'givegold', 'giveexp']:
                 LOGGER.warn("Command disallowed")
                 return
             if game_server == "all":

--- a/cogs/handlers/commands.py
+++ b/cogs/handlers/commands.py
@@ -386,7 +386,7 @@ class Commands:
                 print_formatted_text("Usage: command <GameServer#> <command>")
                 return
             
-            if isinstance(command[0],str) and command[0].lower() not in ['message','terminateplayer','serverreset','flushserverlogs', 'givegold', 'giveexp']:
+            if isinstance(command[0],str) and command[0].lower() not in ['message','terminateplayer','serverreset','flushserverlogs']:
                 LOGGER.warn("Command disallowed")
                 return
             if game_server == "all":

--- a/cogs/misc/setup.py
+++ b/cogs/misc/setup.py
@@ -108,7 +108,8 @@ class SetupEnvironment:
                 "svr_startup_timeout": 180,
                 "svr_api_port": 5000,
                 "man_use_cowmaster": False,
-                "svr_restart_between_games": False
+                "svr_restart_between_games": False,
+                "svr_beta_mode": False
             },
             "application_data": {
                 "timers": {

--- a/cogs/misc/utilities.py
+++ b/cogs/misc/utilities.py
@@ -294,7 +294,7 @@ class Misc:
     def get_svr_version(self,hon_exe):
         def validate_version_format(version):
             version_parts = version.split('.')
-            if len(version_parts) != 4:
+            if len(version_parts) < 3:
                 return False
 
             for part in version_parts:


### PR DESCRIPTION
By enabling "beta" mode in the config.json file, the manager will use the LXS gitea branch for patches and server launcher versions.